### PR TITLE
Replace compass task with sass task for substantial speed improvements.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
 
 	/* define the tasks to run when run with 'grunt' */
 	grunt.registerTask("default", [
-		"compass",
+		"sass",
 		"copy",
 		"shell:patternlab"
 	]);

--- a/build/tasks/sass.js
+++ b/build/tasks/sass.js
@@ -1,0 +1,18 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks("grunt-sass");
+
+  grunt.config("sass", {
+    options: {
+      includePaths: ["bower_components/foundation/scss"]
+    },
+    dist: {
+      files: [{
+        expand: true,
+        cwd: 'www/source/scss',
+        src: ['*.{scss,sass}'],
+        dest: '../../tmp/css/',
+        ext: '.css'
+      }]
+    }
+  });
+};

--- a/build/tasks/watch.js
+++ b/build/tasks/watch.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
 	grunt.config("watch", {
 		css: {
 			files: ["www/source/scss/**/*.scss", "www/source/scss/*.scss"],
-			tasks: ["compass", "copy:css", "shell:patternlab"],
+			tasks: ["sass", "copy:css", "shell:patternlab"],
 			options: {
 				spawn: false,
 				livereload: true

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
   "author": "HBR Tech",
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-uglify": "~0.6.0",
-    "grunt-contrib-copy": "~0.7.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-compass": "~1.0.1",
     "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-copy": "~0.7.0",
     "grunt-contrib-csslint": "~0.3.1",
     "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-uglify": "~0.6.0",
+    "grunt-contrib-watch": "~0.6.1",
     "grunt-jscs-checker": "~0.8.1",
+    "grunt-sass": "^0.17.0",
     "grunt-shell": "~0.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Compiling sass with compass is a bit slow. Since daisy is using compass to simply compile scss, I replaced (but didn't remove) the`grunt-contrib-compass` task with the `grunt-sass` task. Note that this is not using `grunt-contrib-sass` which is written in ruby and still a bit slow. Instead, `grunt-sass` uses `libsass` which is written in C++ and very fast.

I hope this is useful for you all. We're currently using this patch here: https://github.com/cityofphiladelphia/patterns

Thanks for your great work! Let me know if I can improve this further.